### PR TITLE
Update SessionCenter.swift

### DIFF
--- a/FileDownloadingCenter/Classes/DownloadCenter/SessionCenter.swift
+++ b/FileDownloadingCenter/Classes/DownloadCenter/SessionCenter.swift
@@ -181,7 +181,7 @@ public class SessionCenter : NSObject {
         
         var downloader : FileDownloader?
         
-        if let url = task.currentRequest?.url, let _downloader = self.downloaders[url], _downloader.sessionData.session == session {
+        if let url = task.originalRequest?.url, let _downloader = self.downloaders[url], _downloader.sessionData.session == session {
             
             downloader = _downloader
             


### PR DESCRIPTION
"currentRequest" may change for redirection or something like this, so, we should use: "originalRequest" instead